### PR TITLE
ci: migrate GCP auth to managed WIF identity

### DIFF
--- a/.github/workflows/deploy-network-provider-verification-demo.yml
+++ b/.github/workflows/deploy-network-provider-verification-demo.yml
@@ -34,8 +34,8 @@ jobs:
       - name: configure gcp credentials
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: "projects/1043231896197/locations/global/workloadIdentityPools/github-actions-pool/providers/github"
-          service_account: "github-actions@the-mee-foundation.iam.gserviceaccount.com"
+          workload_identity_provider: "projects/1043231896197/locations/global/workloadIdentityPools/github-actions-pool/providers/global-github-deployment"
+          service_account: "global-github-actions@the-mee-foundation.iam.gserviceaccount.com"
       - name: deploy to bucket
         run: |
           gcloud storage rsync --recursive ${{ env.path_to_app }}/dist gs://${{ env.bucket_name }}


### PR DESCRIPTION
## Migrate GCP auth to the Terraform-managed Workload Identity Federation identity

**Why:** these workflows authenticate to GCP (`the-mee-foundation`) via a **legacy, unmanaged** WIF provider (`github`) + service account (`github-actions@`). That provider's attribute condition and SA bindings are hand-maintained and were left stale — e.g. the `mee-foundation-website` -> `tmf-website` rename broke auth with `unauthorized_client / rejected by the attribute condition`.

This repoints them to the **IaC-managed** identity, defined in the `ops` repo's `github_cicd` Terraform module:
- provider `github` -> `global-github-deployment`
- SA `github-actions@` -> `global-github-actions@`

The managed SA has been granted the same project roles as the legacy SA (artifactregistry.writer, container.admin/clusterViewer, compute.loadBalancerAdmin, storage.admin/objectAdmin), so Docker-push and GKE workflows keep working.

Part of a coordinated migration across all MeeFoundation repos; the legacy `github` provider + `github-actions@` SA will be retired once every repo is migrated and green.